### PR TITLE
fixing payline match revert

### DIFF
--- a/Assumptions
+++ b/Assumptions
@@ -2,10 +2,10 @@
 A payline might have multiple matches from different rows, this case is not catered for.
 for now just take the biggest match.
 
-2. booard row - payline matches:
+2. booard row - payline matches: (fixed)
 if the board row has 'r 1 r k h' and the payline is 'r k h 1 2', 'r' first match is column 1 so its a logical bug.
 improvement: second 'r' in row should also be considered. to fix, when cell is not matched, move backwards the number of symbols matchesd + 1. 
-Note this is on a single row not like poiint 1 whuich is multiple matches in multiple rows.
+Note this is on a single row not like point 1 whuich is multiple matches in multiple rows.
 
 3. No max paylines:
 a bet might have x amount of paylines, but its always 1 euro. the more paylines, the more winnings :) lol.

--- a/app/Console/Commands/SlotStaticCommand.php
+++ b/app/Console/Commands/SlotStaticCommand.php
@@ -37,6 +37,7 @@ class SlotStaticCommand extends Command {
         $game = new Board($boardConfig);
         $paylines = [
             "8 5 8 11 10", // <-- bug, notice the duplicate '8', should match '5 8 11' but first 8 was skipped
+            "0 3 0 3 6",
             "9 5 8 11 10",
             "0 3 6 9 12",
             "2 5 8 2 2",

--- a/app/Models/Board.php
+++ b/app/Models/Board.php
@@ -115,6 +115,7 @@ class Board implements IBoard
     // keep track of the previouse last matched index so it will be consecutive.
     $previouseRowIndex = -1;
     $previouseCollIndex = -1;
+    $pStartIndex = -1; // keep track which symbol in payline started the consecutive search
     for ($pIndex; $pIndex < $paylineSum; $pIndex++) {
       if ($foundMatch) {
         // searching ne
@@ -149,6 +150,9 @@ class Board implements IBoard
                 $foundMatch = true;
               }
               if ($foundMatch) {
+                if ($pStartIndex == -1) {
+                  $pStartIndex = $pIndex; // keep track of starting point for consecutive search
+                }
                 $previouseCollIndex = $colIndex;
                 $previouseRowIndex = $rowIndex;
                 array_push($foundSymbols, $cell);
@@ -161,11 +165,25 @@ class Board implements IBoard
               } else {
                 $previouseCollIndex = -1;
                 $previouseRowIndex = -1;
+                $countSymbols = count($foundSymbols);
                 // if found < 3 then reset foundSymbols to empty.
-                if (count($foundSymbols) < $minMatch) {
+                if ($countSymbols < $minMatch) {
                   Log::debug("[clear] cellVal: " . $cellVal);
                   // clear, dont bother if its less then minMatch
                   $foundSymbols = [];
+                }
+                // it is not last payline symbol check?
+                if ($countSymbols > 0 && $pIndex < $paylineSum - 1) {
+                  // if ($countSymbols >= $minMatch) skip payline symbols by countSymbols,
+                  // else go back to where consecutive search started + 1 for next symbol in payline
+                  // $nextPIndex = $countSymbols < $minMatch ? ($pStartIndex + 1) : $pStartIndex + $countSymbols;
+                  $nextPIndex = ($pStartIndex + 1);
+                  Log::info("[revert] pIndex: " . $pIndex . " revert-pIndex:" . $nextPIndex);
+                  // step back/revert and reset symbol loop to countSymbols + 1 as 'next' symbol
+                  $pIndex = $nextPIndex;
+                  $pStartIndex = -1;
+                  Log::info("[revert] colIndex: " . $colIndex . " revert-colIndex:" . (($colIndex - $countSymbols) + 1));
+                  $colIndex = ($colIndex - $countSymbols) + 1; // start searching new consecutive search
                 }
               }
 


### PR DESCRIPTION
fixing an issue with matching payline against  a row. example: 
payline: "0 3 0 3 6"
row in board: "0 4 0 3 6"
expected match: "0 3 6"
actual: no match as it tries to match first "0 3" which will fail as "0  3 0" not in payline, then check pointers are not reverted back to 'next' cell check
